### PR TITLE
Fix unused model_prompt variable and update repository URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Before using this workflow agent, ensure you have:
 
 1. **Clone the repository**:
    ```bash
-   git clone https://github.com/your-username/Slack2Jira.git
+   git clone https://github.com/redhat-ai-tools/Slack2Jira.git
    cd Slack2Jira
    ```
 

--- a/Slack2Jira_Workflow_Agent.ipynb
+++ b/Slack2Jira_Workflow_Agent.ipynb
@@ -346,6 +346,7 @@
     "    client=client,\n",
     "    model=model_id,\n",
     "    tools=[\"mcp::slack\", \"mcp::jira\"],\n",
+    "    instructions=model_prompt,\n",
     "    response_format={\n",
     "        \"type\": \"json_schema\",\n",
     "        \"json_schema\": ReActOutput.model_json_schema(),\n",


### PR DESCRIPTION
This PR fixes two important issues:

## 🐛 Bug Fix: Unused model_prompt Variable
- **Problem**: The `model_prompt` variable was defined but never used in the ReActAgent initialization
- **Fix**: Added `instructions=model_prompt` parameter to the ReActAgent constructor
- **Impact**: Now the agent properly uses the specialized Slack-to-Jira workflow instructions for better performance

## 📚 Documentation Fix: Repository URL
- **Problem**: README contained placeholder URL `https://github.com/your-username/Slack2Jira.git`
- **Fix**: Updated to correct URL `https://github.com/redhat-ai-tools/Slack2Jira.git`
- **Impact**: Users can now properly clone the repository using the installation instructions

## 🔍 Changes Made

### Notebook Changes (`Slack2Jira_Workflow_Agent.ipynb`)
```python
# Before
agent = ReActAgent(
    client=client,
    model=model_id,
    tools=["mcp::slack", "mcp::jira"],
    response_format={...},
    sampling_params={"max_tokens": 1024},
)

# After
agent = ReActAgent(
    client=client,
    model=model_id,
    tools=["mcp::slack", "mcp::jira"],
    instructions=model_prompt,  # ← Added this line
    response_format={...},
    sampling_params={"max_tokens": 1024},
)
```

### README Changes
```diff
- git clone https://github.com/your-username/Slack2Jira.git
+ git clone https://github.com/redhat-ai-tools/Slack2Jira.git
```

## ✅ Testing
- [x] Code compiles without errors
- [x] Agent now properly receives the specialized workflow instructions
- [x] Installation instructions are accurate

These changes ensure the workflow agent functions as intended and users can successfully set up the project.